### PR TITLE
Add Brew path to .zshrc in order to fix following errors:

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -1,3 +1,5 @@
+# Add Brew path
+PATH=/usr/local/bin:$PATH
 
 # Functions
 fpath=( "$HOME/.zsh/functions" "/usr/local/share/zsh-completions" $fpath )


### PR DESCRIPTION
/Users/foo/.zsh/plugins.zsh:25: command not found: brew
/Users/foo/.zsh/plugins.zsh:26: command not found: brew
/Users/foo/.zsh/plugins.zsh:30: command not found: brew
/Users/foo/.zsh/plugins.zsh:33: command not found: brew